### PR TITLE
Replace all instances of 'express-template' with

### DIFF
--- a/app/controllers/root.js
+++ b/app/controllers/root.js
@@ -6,7 +6,7 @@ const controller = require('lib/wiring/controller');
 const root = (req, res) => {
   res.json({
     index: {
-      title: 'Express Template',
+      title: 'event-planner-api',
       environment: req.app.get('env'),
     },
   });

--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('express-template:users');
+const debug = require('debug')('event-planner-api:users');
 
 const controller = require('lib/wiring/controller');
 const models = require('app/models');

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const debug = require('debug')('express-template:error-handler');
+const debug = require('debug')('event-planner-api:error-handler');
 
 const errorHandler = (err, req, res, next) => {
   //jshint unused:false

--- a/app/middleware/mongoose.js
+++ b/app/middleware/mongoose.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const mongoose = require('mongoose');
-const uri = process.env.MONGOLAB_URI || 'mongodb://localhost/express-template';
+const uri = process.env.MONGOLAB_URI || 'mongodb://localhost/event-planner-api';
 mongoose.Promise = global.Promise;
 mongoose.connect(uri);
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "express-api-template",
+  "name": "event-planner-api",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ app.use(middleware['404']);
 // error handlers
 app.use(middleware['error-handler']);
 
-const debug = require('debug')('express-template:server');
+const debug = require('debug')('event-planner-api:server');
 const http = require('http');
 
 /**


### PR DESCRIPTION
app name.

Per API setup instructions, replaced all instances of 'express-template'
'express-api-template', and 'express template' with 'event-planner-api'.
