### PR TITLE
Update Destroy on Events Controller

### DIFF
--- a/app/controllers/events.js
+++ b/app/controllers/events.js
@@ -3,6 +3,7 @@
 const controller = require('lib/wiring/controller');
 const models = require('app/models');
 const Event = models.event;
+const Rsvp = models.rsvp;
 
 const authenticate = require('./concerns/authenticate');
 
@@ -59,11 +60,11 @@ const destroy = (req, res, next) => {
       if (!event) {
         return next();
       }
-
-      return event.remove()
+      return Rsvp.remove({ _event: req.params.id })
+      .then(() => event.remove())
         .then(() => res.sendStatus(200));
     })
-    .catch(err => next(err));
+      .catch(err => next(err));
 };
 
 module.exports = controller({

--- a/scripts/rsvp.sh
+++ b/scripts/rsvp.sh
@@ -1,7 +1,7 @@
 #index
 
 curl --include --request GET http://localhost:3000/rsvps \
-  --header "Authorization: Token token=$TOKEN"
+  --header "Authorization: Token token=aj9fa4wOCRkNpCgcH9TYKPq98IuMpm0fw+va4NjLkQw=--j6Cm14HNfSPCy3cmzEmbficmie8s3zDBPuuxrP6uJ0Q="
 
 #show
 
@@ -12,18 +12,15 @@ curl --include --request GET http://localhost:3000/rsvps/58029237eb8835c86266961
 
 curl --include --request POST http://localhost:3000/rsvps \
   --header "Content-Type: application/json" \
-  --header "Authorization: Token token=$TOKEN" \
+  --header "Authorization: Token token=aj9fa4wOCRkNpCgcH9TYKPq98IuMpm0fw+va4NjLkQw=--j6Cm14HNfSPCy3cmzEmbficmie8s3zDBPuuxrP6uJ0Q=" \
   --data '{
     "rsvp": {
-      "_event": "5802865deb8835c862669610",
-      "title": "Bagel Party",
-      "location": "GA Boston",
-      "date": "2016-10-15",
+      "_event": "580299b5eb8835c862669613",
       "questions":
       [
         {
           "text": "Are you coming?",
-          "answer": [ "Maybe" ]
+          "answer": [ "YASSS" ]
         }
       ]
     }


### PR DESCRIPTION
After learning that mongo doesn't not automatically delete rsvps
when the event they're associated with is deleted, we updated the destroy
action on the events controller to fix this.

Now, when the delete request is made, first, the rsvps associated with
the given event id are deleted, and then the event itself is deleted.

Also updated the rsvp curl script to remove title, date and time since
we no longer need to pass those.
