### PR TITLE
Make event#update return event data instead of just a status code

### DIFF
--- a/app/controllers/events.js
+++ b/app/controllers/events.js
@@ -48,7 +48,7 @@ const update = (req, res, next) => {
 
       delete req.body._owner;
       return event.update(req.body.event)
-        .then(() => res.sendStatus(200));
+        .then(() => res.json({ event }));
     })
     .catch(err => next(err));
 };


### PR DESCRIPTION
When event is successfully updated, return the event data instead of a plain status code
