### PR TITLE
Send back actual updated event data

### DIFF
--- a/app/controllers/events.js
+++ b/app/controllers/events.js
@@ -48,7 +48,8 @@ const update = (req, res, next) => {
 
       delete req.body._owner;
       return event.update(req.body.event)
-        .then(() => res.json({ event }));
+        .then(() => Event.findOne(search))
+        .then((event) => res.json({ event }));
     })
     .catch(err => next(err));
 };


### PR DESCRIPTION
Was sending back original, un-updated event data (whoops!)

If event successfully updates, then:
- find the event again (in order to get the new data)
- send back the new, shiny, updated data
