### PR TITLE
Use update with upsert instead of create for RSVPs

### DIFF
--- a/app/controllers/rsvps.js
+++ b/app/controllers/rsvps.js
@@ -47,7 +47,7 @@ const create = (req, res, next) => {
         _owner: req.currentUser._id,
       });
 
-      return Rsvp.create(rsvp);
+      return Rsvp.update({ _event: req.body.rsvp._event, _owner: req.currentUser._id}, rsvp, { upsert: true});
     })
     .then(rsvp => res.json({ rsvp }))
     .catch(err => next(err));


### PR DESCRIPTION
Use update with upsert inside of rsvps#create.

This prevents us from creating two RSVPs for the same user for the same event.
If an RSVP exists for that user for that event, update with upsert will overwrite (update) the existing RSVP.
If no RSVP exists, update with upsert will create a new RSVP.
