### PR TITLE
Populate RSVPs for a single event on update

### DIFF
--- a/app/controllers/events.js
+++ b/app/controllers/events.js
@@ -71,7 +71,7 @@ const update = (req, res, next) => {
 
       delete req.body._owner;
       return event.update(req.body.event)
-        .then(() => Event.findOne(search))
+        .then(() => Event.findOne(search).populate('rsvps'))
         .then((event) => res.json({ event }));
     })
     .catch(err => next(err));


### PR DESCRIPTION
When updating an event, populate the rsvps before sending it back.
This makes sure that we have RSVPs when we try to display that event.

(Missed one place that we need to include `.populate('rsvps')` earlier today, and just caught it when I was trying to test out updating an event. Now that we're calculating RSVPs, we need to include this statement every time we send any kind of event data back through the API to the client.)
